### PR TITLE
Update messages-recv.ts

### DIFF
--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -42,7 +42,6 @@ import {
 } from '../WABinary'
 import { extractGroupMetadata } from './groups'
 import { makeMessagesSocket } from './messages-send'
-import Long from "long"
 
 export const makeMessagesRecvSocket = (config: SocketConfig) => {
 	const {

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -833,7 +833,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 				chatJid: oldestMsgKey.remoteJid,
 				oldestMsgFromMe: oldestMsgKey.fromMe,
 				oldestMsgId: oldestMsgKey.id,
-				oldestMsgTimestampMs: oldestMsgTimestamp,
+				oldestMsgTimestampMs: oldestMsgTimestamp as number | Long | null | undefined,
 				onDemandMsgCount: count
 			},
 			peerDataOperationRequestType: proto.Message.PeerDataOperationRequestType.HISTORY_SYNC_ON_DEMAND

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -42,6 +42,7 @@ import {
 } from '../WABinary'
 import { extractGroupMetadata } from './groups'
 import { makeMessagesSocket } from './messages-send'
+import Long from "long"
 
 export const makeMessagesRecvSocket = (config: SocketConfig) => {
 	const {

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -833,7 +833,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 				chatJid: oldestMsgKey.remoteJid,
 				oldestMsgFromMe: oldestMsgKey.fromMe,
 				oldestMsgId: oldestMsgKey.id,
-				oldestMsgTimestampMs: oldestMsgTimestamp as number | Long | null | undefined,
+				oldestMsgTimestampMs: Number(oldestMsgTimestamp),
 				onDemandMsgCount: count
 			},
 			peerDataOperationRequestType: proto.Message.PeerDataOperationRequestType.HISTORY_SYNC_ON_DEMAND


### PR DESCRIPTION
```
Run yarn
  yarn
  shell: /usr/bin/bash -e {0}
  env:
    NODE_AUTH_TOKEN: ***
yarn install v1.[2](https://github.com/wkarts/Baileys/actions/runs/10419571902/job/28857896043#step:8:2)2.22
[1/4] Resolving packages...
[2/4] Fetching packages...
[[3](https://github.com/wkarts/Baileys/actions/runs/10419571902/job/28857896043#step:8:3)/4] Linking dependencies...
[[4](https://github.com/wkarts/Baileys/actions/runs/10419571902/job/28857896043#step:8:4)/4] Building fresh packages...
$ tsc
Error: src/Socket/messages-recv.ts(842,39): error TS234[5](https://github.com/wkarts/Baileys/actions/runs/10419571902/job/28857896043#step:8:5): Argument of type '{ historySyncOnDemandRequest: { chatJid: string | null | undefined; oldestMsgFromMe: boolean | null | undefined; oldestMsgId: string | null | undefined; oldestMsgTimestampMs: number | Long.Long; onDemandMsgCount: number; }; peerDataOperationRequestType: proto.Message.PeerDataOperationRequestType; }' is not assignable to parameter of type 'IPeerDataOperationRequestMessage'.
  The types of 'historySyncOnDemandRequest.oldestMsgTimestampMs' are incompatible between these types.
    Type 'number | Long' is not assignable to type 'number | Long | null | undefined'.
      Type 'Long' is not assignable to type 'number | Long | null | undefined'.
        Type 'Long' is missing the following properties from type 'Long': ge, eqz, le, rem, and [10](https://github.com/wkarts/Baileys/actions/runs/10419571902/job/28857896043#step:8:11) more.
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
Error: Process completed with exit code 2.
```
O erro ocorre porque há uma incompatibilidade de tipos entre o que é esperado e o que está sendo passado como argumento para a função `sendPeerDataOperationMessage`.

### Identificação do Problema

Na função `fetchMessageHistory`, a linha que define `pdoMessage` está assim:

```typescript
const pdoMessage = {
    historySyncOnDemandRequest: {
        chatJid: oldestMsgKey.remoteJid,
        oldestMsgFromMe: oldestMsgKey.fromMe,
        oldestMsgId: oldestMsgKey.id,
        oldestMsgTimestampMs: oldestMsgTimestamp,
        onDemandMsgCount: count
    },
    peerDataOperationRequestType: proto.Message.PeerDataOperationRequestType.HISTORY_SYNC_ON_DEMAND
}
```

O problema está na linha:

```typescript
oldestMsgTimestampMs: oldestMsgTimestamp,
```

Aqui, `oldestMsgTimestamp` é do tipo `number | Long`, mas o TypeScript está exigindo que ele seja do tipo `number | Long | null | undefined`.

### Correção

Para resolver isso, podemos garantir que o tipo esteja compatível com o que é esperado. Uma maneira de fazer isso é explicitamente permitir que o valor seja `null` ou `undefined` usando uma conversão de tipo.

```typescript
const pdoMessage = {
    historySyncOnDemandRequest: {
        chatJid: oldestMsgKey.remoteJid,
        oldestMsgFromMe: oldestMsgKey.fromMe,
        oldestMsgId: oldestMsgKey.id,
        oldestMsgTimestampMs: oldestMsgTimestamp as number | Long | null | undefined,
        onDemandMsgCount: count
    },
    peerDataOperationRequestType: proto.Message.PeerDataOperationRequestType.HISTORY_SYNC_ON_DEMAND
}
```
